### PR TITLE
Refresh MiniMax model pricing

### DIFF
--- a/src/session/cost.test.ts
+++ b/src/session/cost.test.ts
@@ -38,7 +38,7 @@ describe("人民币计费", () => {
     expect(def.inputMiss).toBeCloseTo(1.25 * 6.8, 5);
   });
 
-  it("MiniMax 官方模型 ID 与小写别名使用当前美元价格", () => {
+  it("uses current USD prices for official MiniMax model IDs and lowercase aliases", () => {
     const m3 = { inputHit: 0.84, inputMiss: 4.2, output: 16.8 };
     const m27 = { inputHit: 0.42, inputMiss: 2.1, output: 8.4 };
 

--- a/src/session/cost.test.ts
+++ b/src/session/cost.test.ts
@@ -38,6 +38,16 @@ describe("人民币计费", () => {
     expect(def.inputMiss).toBeCloseTo(1.25 * 6.8, 5);
   });
 
+  it("MiniMax 官方模型 ID 与小写别名使用当前美元价格", () => {
+    const m3 = { inputHit: 0.84, inputMiss: 4.2, output: 16.8 };
+    const m27 = { inputHit: 0.42, inputMiss: 2.1, output: 8.4 };
+
+    expect(pricesFor("MiniMax-M3", { DAO_USD_CNY_RATE: "7" } as any)).toEqual(m3);
+    expect(pricesFor("minimax-m3", { DAO_USD_CNY_RATE: "7" } as any)).toEqual(m3);
+    expect(pricesFor("MiniMax-M2.7", { DAO_USD_CNY_RATE: "7" } as any)).toEqual(m27);
+    expect(pricesFor("minimax-m2.7", { DAO_USD_CNY_RATE: "7" } as any)).toEqual(m27);
+  });
+
   it("未知模型名仍退化到 pro/flash 启发式,不报错", () => {
     expect(pricesFor("some-new-flash-model").inputMiss).toBe(1);
     expect(pricesFor("some-new-model").inputMiss).toBe(3);

--- a/src/session/cost.ts
+++ b/src/session/cost.ts
@@ -22,13 +22,15 @@ export const KNOWN_PRICES: Record<string, Prices> = {
   "glm-5.1": { inputHit: 1.3, inputMiss: 6, output: 24 },
   "kimi-k2.6": { inputHit: 1.1, inputMiss: 6.5, output: 27 },
   "kimi-k2.7-code": { inputHit: 1.3, inputMiss: 6.5, output: 27 },
-  "minimax-m2.7": { inputHit: 0.42, inputMiss: 2.1, output: 8.4 },
-  "minimax-m3": { inputHit: 0.42, inputMiss: 2.1, output: 8.4 },
   "ernie-5.1": { inputHit: 1.6, inputMiss: 4, output: 18 },
 };
 
 // 美元报价(官方计费页,$/1M tokens)。换算汇率默认 6.8(2026-07 USD/CNY 中间价附近),可用 DAO_USD_CNY_RATE 覆盖。
 const USD_PRICES: Record<string, Prices> = {
+  "MiniMax-M3": { inputHit: 0.12, inputMiss: 0.6, output: 2.4 },
+  "minimax-m3": { inputHit: 0.12, inputMiss: 0.6, output: 2.4 },
+  "MiniMax-M2.7": { inputHit: 0.06, inputMiss: 0.3, output: 1.2 },
+  "minimax-m2.7": { inputHit: 0.06, inputMiss: 0.3, output: 1.2 },
   "claude-opus-4-8": { inputHit: 0.5, inputMiss: 5, output: 25 },
   "gpt-5": { inputHit: 0.125, inputMiss: 1.25, output: 10 },
 };


### PR DESCRIPTION
Reason: MiniMax model pricing entries used generic fallback rates and stale lowercase values.

- Add explicit official MiniMax M3 and M2.7 pricing for canonical IDs and lowercase aliases.
- Cover cache-hit, cache-miss, and output rates with regression tests.
- Checks: `npm test -- --run src/session/cost.test.ts`; `npm run typecheck -- --pretty false`.
