### PR TITLE
docs: add optional You.com remote MCP search example

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,11 +221,40 @@ Built for long tasks that "run autonomously for a long time without drifting, ar
 - **Custom slash commands**: `.dao/commands/<name>.md` (body is a prompt template, `$ARGUMENTS`/`$1`). `/<name> args` expands into a single turn.
 - **Skills (ready-to-use skills)**: `.dao/skills/<name>/SKILL.md`. Progressive disclosure: startup lists only name+description; the model loads the body on demand via the `skill` tool.
 - **Hooks (lifecycle hooks)**: `.dao/hooks.json`. PreToolUse (can block) / PostToolUse (e.g. auto-format) / UserPromptSubmit (inject context / block) / SessionStart / End.
-- **MCP**: `.dao/mcp.json`. Connects to stdio MCP servers; tools auto-register as `mcp__<server>__<tool>`.
+- **MCP**: `.dao/mcp.json`. Connects to stdio and remote (HTTP/SSE) MCP servers; tools auto-register as `mcp__<server>__<tool>`.
 - **Subagent orchestration**: parallel `tasks[]`, async `background:true`, `isolate:true` git-worktree isolation, `task_send` to append instructions to a running task, foreground timeout auto-converts to background, transcripts spilled to `.dao/subagents/`.
 - **Steering**: type during a running turn; Enter queues it, processed automatically once the current turn ends.
 
 > Compatible with Claude Code: `settings.json`, `SKILL.md`, `hooks.json`, and `mcp.json` use the same formats as CC (tool names auto-map, e.g. `Bash↔exec_shell`), so existing CC configs/skills work as-is.
+
+### Example: adding web search via a remote MCP server (optional)
+
+The built-in `web_search` tool uses DuckDuckGo. If you want a stronger hosted search/research backend, any remote MCP server works through the same `mcp.json` — for example [You.com](https://you.com/docs) (search, URL content extraction, cited research). Nothing is connected by default; add it explicitly:
+
+```json
+// ~/.dao/mcp.json (user-level) or <project>/.dao/mcp.json (shared with the repo)
+{
+  "mcpServers": {
+    "you": {
+      "type": "http",
+      "url": "https://api.you.com/mcp",
+      "headers": { "Authorization": "Bearer <YDC_API_KEY>" }
+    }
+  }
+}
+```
+
+- Get a key at [you.com/platform/api-keys](https://you.com/platform/api-keys); keep it out of the committed project file (use the user-level config or your secret store).
+- Keyless alternative: `"url": "https://api.you.com/mcp?profile=free"` with no headers — basic web search only.
+- Tools register as `mcp__you__you-search`, `mcp__you__you-contents`, `mcp__you__you-research` and follow the normal `allow/ask/deny` permission rules (e.g. allow them in `.dao/settings.json` or per-call approval).
+
+You.com also publishes agent skills (`you-web`, `you-research`, `you-finance`, `you-discover`) in the same `SKILL.md` format dao reads, so they install through the built-in skill installer with automatic tool-name adaptation:
+
+```bash
+dao skill add https://github.com/youdotcom-oss/agent-skills --user
+```
+
+Both paths are optional and independent: use the MCP server, the skills, neither, or both.
 
 ## 🛠️ Tool overview
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -223,11 +223,40 @@ dao "把 src/utils.ts 里的 formatDate 改成支持时区"
 - **自定义 slash 命令**:`.dao/commands/<name>.md`(正文为 prompt 模板,`$ARGUMENTS`/`$1`)。`/<name> 参数` 展开成一个回合跑。
 - **Skill(开箱即用技能)**:`.dao/skills/<name>/SKILL.md`。渐进式披露:启动只列 name+description,模型用 `skill` 工具按需加载正文。
 - **Hooks(生命周期钩子)**:`.dao/hooks.json`。PreToolUse(可阻断)/PostToolUse(如自动格式化)/UserPromptSubmit(注入上下文/阻断)/SessionStart/End。
-- **MCP**:`.dao/mcp.json`。连 stdio MCP server,工具自动注册为 `mcp__<server>__<tool>`。
-- **子代理编排**:并行 `tasks[]`、`background:true` 异步后台、`isolate:true` git worktree 隔离、`task_send` 给运行中任务追加指令、前台超时自动转后台、转录落盘 `.dao/subagents/`。
+- **MCP**:`.dao/mcp.json`。连 stdio 与远程(HTTP/SSE)MCP server,工具自动注册为 `mcp__<server>__<tool>`。
+- **子代理编排**:并行 `tasks[]`、`background:true` 异步后台、`isolate:true` git-worktree 隔离、`task_send` 给运行中任务追加指令、前台超时自动转后台、转录落盘 `.dao/subagents/`。
 - **steering**:回合运行中也能打字,回车排队,当前回合结束后自动处理。
 
 > 兼容 Claude Code:`settings.json`、`SKILL.md`、`hooks.json`、`mcp.json` 与 CC 同款格式(工具名自动映射 `Bash↔exec_shell` 等),现成的 CC 配置/技能可直接拿来用。
+
+### 示例:通过远程 MCP server 加配联网搜索(可选)
+
+内置 `web_search` 走 DuckDuckGo。想要更强的托管搜索/研究后端时,任何远程 MCP server 都走同一个 `mcp.json`——例如 [You.com](https://you.com/docs)(搜索、URL 正文提取、带引用的研究)。默认不连任何 server,需要显式添加:
+
+```json
+// ~/.dao/mcp.json(用户级)或 <项目>/.dao/mcp.json(随仓库共享)
+{
+  "mcpServers": {
+    "you": {
+      "type": "http",
+      "url": "https://api.you.com/mcp",
+      "headers": { "Authorization": "Bearer <YDC_API_KEY>" }
+    }
+  }
+}
+```
+
+- 在 [you.com/platform/api-keys](https://you.com/platform/api-keys) 取 key;别把 key 提交进项目文件(用用户级配置或密钥管理)。
+- 免 key 替代:`"url": "https://api.you.com/mcp?profile=free"` 且不带 headers——仅基础网页搜索。
+- 工具注册为 `mcp__you__you-search`、`mcp__you__you-contents`、`mcp__you__you-research`,走既有 `allow/ask/deny` 权限规则(在 `.dao/settings.json` 加 allow 或按次审批)。
+
+You.com 也发布了 agent 技能(`you-web`、`you-research`、`you-finance`、`you-discover`),与 dao 读取的 `SKILL.md` 同格式,经内置技能安装器安装,外来技能的工具名自动适配:
+
+```bash
+dao skill add https://github.com/youdotcom-oss/agent-skills --user
+```
+
+两条路径各自独立、均可选:MCP server、技能、都不用、或都用,随你。
 
 ## 🛠️ 工具一览
 


### PR DESCRIPTION
## 做了什么 / What

Docs-only change to the extension-system section of both READMEs:

1. **Fixed the MCP bullet**: it said `.dao/mcp.json` connects to stdio servers only, but `src/mcp/mcp.ts` also supports remote HTTP (Streamable HTTP) and SSE transports. The bullet now mentions them.
2. **Added a worked example** for the most common thing people want to add to a coding agent — hosted web search — using You.com's remote MCP server through the *existing* config surface:

```json
{
  "mcpServers": {
    "you": {
      "type": "http",
      "url": "https://api.you.com/mcp",
      "headers": { "Authorization": "Bearer <YDC_API_KEY>" }
    }
  }
}
```

3. **Mentioned the skills path**: You.com publishes agent skills (`you-web`, `you-research`, `you-finance`, `you-discover`) in the same `SKILL.md` format dao reads, so `dao skill add https://github.com/youdotcom-oss/agent-skills --user` installs them through the built-in installer (foreign tool-name auto-adaptation applies).

## 为什么 / Why

The built-in `web_search` uses DuckDuckGo, which is fine for quick lookups but weak for current docs, full-page content extraction, and cited research — the things `explore`/`plan` subagents end up doing on research-ish tasks. dao's MCP client already handles remote HTTP servers with auth headers, so this is a one-config-entry upgrade rather than any new code. The HTTP transport path is already covered by `src/mcp/mcp.http.test.ts`.

## 形状 / Shape

- No code changes, no new dependencies, no config shipped — nothing is connected or installed by default; the example is explicitly opt-in.
- API key guidance points at the user-level `~/.dao/mcp.json` (or a secret store) so keys don't land in committed project files.
- Keyless variant documented too: `https://api.you.com/mcp?profile=free` (basic search only, no headers).
- Tools land as `mcp__you__you-search` / `you-contents` / `you-research` and follow the normal allow/ask/deny rules, so no permission changes either.

## 验证 / Validation

- `npm run typecheck` ✅ · `npm run lint` (0 errors) ✅ · `npm test` (191 files, 1790 tests) ✅ · `npm run build` ✅
- JSON snippets parsed programmatically.
- Live handshake check against the documented keyless endpoint (`initialize` over Streamable HTTP) returns a valid MCP response, so the config shape in the example matches what the client expects and what the server serves.

Happy to trim this to just the MCP example (or just the stdio→HTTP bullet fix) if you'd rather keep the README lean — the two edits are independent.